### PR TITLE
requestAnimationFrame polyfill

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "license": "MIT",
   "dependencies": {
     "delaunay-triangulate": "^1.1.6",
-    "parse-svg-path": "^0.1.1"
+    "parse-svg-path": "^0.1.1",
+    "raf": "^2.0.3"
   }
 }

--- a/src/rendering.js
+++ b/src/rendering.js
@@ -1,6 +1,7 @@
 'use strict'
 
 var random = Math.random;
+var RAF = require('raf');
 
 module.exports = function(container){
     
@@ -114,7 +115,7 @@ module.exports = function(container){
         tick();
         
         if(!paused)
-            requestAnimationFrame(animate);
+            RAF(animate);
     };
     animate();
     


### PR DESCRIPTION
Fix Safari 6, vendor prefixed browsers and non-RAF compatible browsers Ants animation.
